### PR TITLE
[FIX] require should look for files first

### DIFF
--- a/runtime_library/module.js
+++ b/runtime_library/module.js
@@ -55,7 +55,7 @@
     extension = splitPath(path).ext.toLowerCase();
     if (!extension) {
 
-      path = tryModule(path) || tryNodeModule(path) || tryFile(path) || tryDirectory(path) || path;
+      path = tryFile(path) || tryModule(path) || tryNodeModule(path) || tryDirectory(path) || path;
 
       extension = splitPath(path).ext.toLowerCase();
     }


### PR DESCRIPTION
There is a broken test case because instead of just checking for the files first it should be more intelligent about whether it is trying to require a file or a module (i.e. look for the "./")
