### PR TITLE
RealFilesystem fs proxy was only passing the first argument to the fs methods.

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -218,18 +218,10 @@ Compiler.prototype.setFilesystem = function (filesystem) {
 };
 
 Compiler.RealFilesystem = {
-  readFile: function (filename) {
-    return fs.readFileSync(filename);
-  },
-  stat: function (filename) {
-    return fs.statSync(filename);
-  },
-  readdir: function (dirname) {
-    return fs.readdirSync(dirname)
-  },
-  exists: function (filename) {
-    return fs.existsSync(filename);
-  }
+  readFile: fs.readFileSync.bind(fs),
+  stat: fs.statSync.bind(fs),
+  readdir: fs.readdirSync.bind(fs),
+  exists: fs.existsSync.bind(fs)
 };
 
 exports.Compiler = Compiler;

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -139,9 +139,9 @@ Compiler.prototype.generateManifest = function (contractPath) {
       main_possibilities.push(manifest.name + '.js');
 
       // If package.json is found also add the main file from there
-      if (fs.existsSync(path.resolve(contractPath, 'package.json'))) {
+      if (_this._fileSystem.exists(path.resolve(contractPath, 'package.json'))) {
         try {
-          var package_json = fs.readFileSync(path.resolve(contractPath, 'package.json'));
+          var package_json = _this._fileSystem.readFile(path.resolve(contractPath, 'package.json'));
           var package_main = JSON.parse(package_json).main;
           if (typeof package_main === 'string') {
             main_possibilities.push(package_main);


### PR DESCRIPTION
For example, it wouldn't pass along the encoding parameter for readFile. Also cleaned up some naked calls to fs methods for consistency
