### PR TITLE
[FIX] Apply ignore file filter to node_modules

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -50,10 +50,11 @@ util.inherits(Compiler, events.EventEmitter);
  *
  *  @param {String} contractPath Absolute path of the contract or module to compile
  *  @param {Object} manifest Optionally pass in a full or partially filled out manifest
+ *  @param {Array} [null] parent_ignores A list of inherited rules for filtering files
  *
  *  @returns {String} contract_hash The hash of the contract's manifest
  */
-Compiler.prototype.compileModule = function (contractPath, manifest) {
+Compiler.prototype.compileModule = function (contractPath, manifest, parent_ignores) {
   var _this = this;
 
   contractPath = contractPath || '';
@@ -81,7 +82,9 @@ Compiler.prototype.compileModule = function (contractPath, manifest) {
 
   // Normalize (or if needed, generate) manifest properties
   _this._ensureMainProperty(manifest, contractPath);
-  _this._ensureFilesProperty(manifest, contractPath);
+  var ignore_rules=[];
+  if (!parent_ignores) parent_ignores = [];
+  _this._ensureFilesProperty(manifest, contractPath, parent_ignores, ignore_rules);
   _this._ensureModulesProperty(manifest, contractPath);
   _this._ensureApisProperty(manifest);
   _this._ensureEnvProperty(manifest, contractPath);
@@ -99,7 +102,7 @@ Compiler.prototype.compileModule = function (contractPath, manifest) {
         return;
       }
       var modulePath = path.join(modulesPath, moduleName);
-      var moduleHash = _this.compileModule(modulePath);
+      var moduleHash = _this.compileModule(modulePath, null, ignore_rules);
       modulesMap[moduleName] = moduleHash;
     });
     manifest.modules = modulesMap;
@@ -110,7 +113,7 @@ Compiler.prototype.compileModule = function (contractPath, manifest) {
         return;
       }
       var modulePath = path.join(modulesPath, moduleName);
-      var moduleHash = _this.compileModule(modulePath);
+      var moduleHash = _this.compileModule(modulePath, null, ignore_rules);
       if (moduleHash !== expectedModuleHash) {
         throw new Error('Error parsing manifest: Incorrect hash for module: ' + moduleName);
       }
@@ -182,13 +185,13 @@ Compiler.prototype._ensureMainProperty = function (manifest, contractPath) {
   }
 };
 
-Compiler.prototype._ensureFilesProperty = function (manifest, contractPath) {
+Compiler.prototype._ensureFilesProperty = function (manifest, contractPath, parent_ignores, ignore_rules) {
   var _this = this;
 
   if (!manifest.files) {
     // Go through all files and subdirectory files
     // excluding the node_modules
-    manifest.files = _this._findAllFiles(contractPath, [_this.config.manifestFilename, 'node_modules', '.git', _this.config.configFilename]);
+    manifest.files = _this._findAllFiles(contractPath, [_this.config.manifestFilename, 'node_modules', '.git', _this.config.configFilename], [], parent_ignores, ignore_rules);
     manifest.files = manifest.files.map(function (path) {
       return path.substr(contractPath.length + 1);
     });
@@ -339,17 +342,20 @@ Compiler.prototype._ensureEnvProperty = function (manifest, contractPath) {
  *
  * @param {String} dir
  * @param {Array} [null] exclude_list A list of filenames or directory names to skip
+ * @param {Array} [null] parent_ignores A list of inherited rules for filtering files
+  * @param {Array} [null] ignore_rules A to be determined list of rules for filtering files
  *
  * @returns {Array} files Array of full paths for all files in dir
  */
-Compiler.prototype._findAllFiles = function (dir, exclude_list, files, parent_ignores) {
+Compiler.prototype._findAllFiles = function (dir, exclude_list, files, parent_ignores, ignore_rules) {
   var _this = this;
-
   if (!files) files = [];
+  if (!ignore_rules) ignore_rules = [];
 
-  var ignoreFilter = _this._createIgnoreFilter(dir, parent_ignores);
+  var ignoreFilter = _this._createIgnoreFilter(dir, ignore_rules, parent_ignores);
 
   var dir_contents = _this._filesystem.readdir(dir);
+
   dir_contents.forEach(function(filename){
     if (exclude_list && exclude_list.indexOf(filename) !== -1) {
       return;
@@ -359,41 +365,38 @@ Compiler.prototype._findAllFiles = function (dir, exclude_list, files, parent_ig
     if (file_stats.isFile()) {
       files.push(file_path);
     } else if (file_stats.isDirectory()) {
-      _this._findAllFiles(file_path, [], files);
+      _this._findAllFiles(file_path, [], files, ignore_rules);
     }
   });
 
   files = files.filter(ignoreFilter);
-
   return files;
 };
 
-Compiler.prototype._createIgnoreFilter = function(dir, parent_ignores) {
+Compiler.prototype._createIgnoreFilter = function(dir, ignore_rules, parent_ignores) {
   var _this = this;
 
-  if (!_this.ignoreFiles || _this.ignoreFiles.length === 0) {
+  if (parent_ignores && parent_ignores.length > 0) {
+    Array.prototype.push.apply(ignore_rules, parent_ignores);
+  }
+
+  if (_this.ignoreFiles) {
+    _this.ignoreFiles.forEach(function(ignoreFile){
+      var ignoreFilePath = path.join(dir, ignoreFile);
+      if (_this._filesystem.exists(ignoreFilePath)) {
+        var rules = _this._filesystem.readFile(ignoreFilePath, 'utf8').split('\n');
+        Array.prototype.push.apply (ignore_rules, rules);
+      }
+    });
+  }
+
+  if (ignore_rules.length===0) {
     return function(path) {
       return true;
     };
   }
-
-  var ignoreRules;
-  if (parent_ignores && parent_ignores.length > 0) {
-    ignoreRules = parent_ignores.slice();
-  } else {
-    ignoreRules = [];
-  }
-
-  _this.ignoreFiles.forEach(function(ignoreFile){
-    var ignoreFilePath = path.join(dir, ignoreFile);
-    if (_this._filesystem.exists(ignoreFilePath)) {
-      var rules = _this._filesystem.readFile(ignoreFilePath, 'utf8').split('\n');
-      ignoreRules = ignoreRules.concat(rules);
-    }
-  });
-
   return ignore({
-    ignore: ignoreRules
+    ignore: ignore_rules
   }).createFilter();
 };
 


### PR DESCRIPTION
.codiusignore filter rules were not being applied to node_modules.
Now native code and be filtered from modules like ripple-lib.
