### PR TITLE
[FIX] manifest_hash in _loadManifest should be manifestHash

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -145,7 +145,7 @@ Engine.prototype._loadManifest = function(manifestHash) {
   // Load manifest file
   var firstDir = manifestHash.slice(0, 2);
   var secondDir = manifestHash.slice(2, 4);
-  var manifest_path = path.join(self.config.contractsFilesystemPath, firstDir, secondDir, manifest_hash);
+  var manifest_path = path.join(self.config.contractsFilesystemPath, firstDir, secondDir, manifestHash);
   var manifest = fs.readFileSync(manifest_path, { encoding: 'utf8' });
   try {
     manifest = JSON.parse(manifest);


### PR DESCRIPTION
This fixes 'manifest_hash is not defined' error when running contracts.
