### PR TITLE
Better warning when MASTER_SECRET is not provided or is not valid.

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -42,7 +42,11 @@ function Engine(config) {
   // contract-specific secrets and keypairs, as well
   // as the host's keypairs to sign the contracts' public keys
   if (!MASTER_SECRET_REGEX.test(config.MASTER_SECRET)) {
-    config.logger.warn('No secret provided! Generating a random secret, please do not do this in production.');
+    if (typeof config.MASTER_SECRET === 'undefined') {
+      config.logger.warn('No MASTER_SECRET provided! Generating a random secret, please do not do this in production.');
+    } else {
+      config.logger.warn('Invalid MASTER_SECRET format! Generating a random secret, please do not do this in production.');
+    }
     config.MASTER_SECRET = crypto.getRandomMasterSecret();
   }
   self._secrets = self.generateSecrets(config.MASTER_SECRET);


### PR DESCRIPTION
Current implementation prints "No secret provided" when MASTER_SECRET is provided but it doesn't pass the regex test.

It should be also clear that "secret" in "No secret provided" means MASTER_SECRET and not some other secret.
